### PR TITLE
Map 'End' to 'Stop'

### DIFF
--- a/doc/manual.md
+++ b/doc/manual.md
@@ -103,8 +103,13 @@ for more details, see [/src/bindings.h](../src/bindings.h), but here are the imp
 | Right Ctrl+F1     | Help                    |
 | Right Ctrl+F4     | Props                   |
 | Right Ctrl+=      | keypad =                |
+| End               | Stop                    |
 
 \* aka Super, Mod4, Windows, etc
+
+The alternate binding for `Stop` to the `End` key is provided so that
+the `Stop-a` chord can be pressed to enter the boot monitor on
+SPARCstations.
 
 ## updating the firmware
 

--- a/src/bindings.h
+++ b/src/bindings.h
@@ -275,6 +275,9 @@ const SelBinding SEL_BINDINGS[] = {
   {70, 0x16, 0x96}, // PrintScreen/SysRq aka “Keyboard PrintScreen” → 70. Pr Sc
   {71, 0x17, 0x97}, // Keyboard Scroll Lock → 71. Break(!)	Scroll Lock
 
+  // Map End to Stop to provide for a way to press Stop-a
+  {77, 0x01, 0x81}, // End -> Stop
+
   // HID Usage Tables 1.3 §10:
   // Keyboard Application[11] Windows key for Windows 95, and Compose.
   // Keyboard Left GUI[11] Windows key for Windows 95, and Compose.


### PR DESCRIPTION
This provides a way to press Stop-a to enter the boot monitor on SPARCstations.