### PR TITLE
Use HTTPS for Submodules, add missing submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,12 @@
 [submodule "hardware/pcb/KiCad-RP-Pico"]
 	path = hardware/pcb/KiCad-RP-Pico
-	url = git@github.com:ncarandini/KiCad-RP-Pico.git
+	url = https://github.com/ncarandini/KiCad-RP-Pico.git
+[submodule "hardware/pcb/KiCad-SSD1306_OLED-0.91-128x32"]
+	path = hardware/pcb/KiCad-SSD1306_OLED-0.91-128x32
+	url = https://github.com/MichMich/KiCad-SSD1306_OLED-0.91-128x32.git
 [submodule "hardware/pcb/KiCad-SSD1306-0.91-OLED-4pin-128x32.pretty"]
 	path = hardware/pcb/KiCad-SSD1306-0.91-OLED-4pin-128x32.pretty
-	url = git@github.com:gorbachev/KiCad-SSD1306-0.91-OLED-4pin-128x32.pretty.git
+	url = https://github.com/gorbachev/KiCad-SSD1306-0.91-OLED-4pin-128x32.pretty.git
 [submodule "hardware/pcb/KiCad-marbastlib"]
 	path = hardware/pcb/KiCad-marbastlib
-	url = git@github.com:ebastler/marbastlib.git
+	url = https://github.com/ebastler/marbastlib.git


### PR DESCRIPTION
Fixes auth error for users without SSH keys in GitHub (e.g. fetch
 only users).